### PR TITLE
Upgrade to Babel 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["stage-0", "es2015", "react"],
+  "plugins": ["transform-decorators-legacy"]
+}

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ const App = React.createClass({
                                    if you're concerned about improving performance */
           <MyComponent />
         </LazyLoad>
-        <LazyLoad height={200} offset={100}> 
+        <LazyLoad height={200} offset={100}>
                                 /* This component will be loaded when it's top
                                    edge is 100px from viewport. It's useful to
                                    make user ignorant about lazy load effect. */
@@ -170,6 +170,7 @@ Using `LazyLoad` component will help ease this situation by only update componen
 ## Contributors
 
 1. [lancehub](https://github.com/lancehub)
+2. [doug-wade](https://github.com/doug-wade)
 
 
 ## License

--- a/examples/pages/decorator.js
+++ b/examples/pages/decorator.js
@@ -53,4 +53,3 @@ export default class Decorator extends Component {
     );
   }
 }
-

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "Lazyload your Component, Image or anything matters the performance.",
   "main": "lib/index.js",
   "scripts": {
-    "test": "./node_modules/karma/bin/karma start test/karma.conf.js",
-    "demo:watch": "./node_modules/.bin/webpack-dev-server --inline --config webpack.config.js --content-base examples --port 8721",
-    "demo:build": "NODE_ENV=production ./node_modules/.bin/webpack",
-    "build": "./node_modules/.bin/babel src/ --out-dir lib/ --stage 0 --loose all",
-    "lint": "./node_modules/.bin/eslint -c .eslintrc src/"
+    "test": "karma start test/karma.conf.js",
+    "demo:watch": "webpack-dev-server --inline --config webpack.config.js --content-base examples --port 8721",
+    "demo:build": "NODE_ENV=production webpack",
+    "build": "babel src/ --out-dir lib/",
+    "lint": "eslint -c .eslintrc src/"
   },
   "repository": {
     "type": "git",
@@ -26,10 +26,15 @@
   },
   "homepage": "https://github.com/jasonslyvia/react-lazyload",
   "devDependencies": {
-    "babel": "~5.8.21",
-    "babel-core": "~5.8.21",
+    "babel": "~6.5.2",
+    "babel-cli": "^6.7.7",
+    "babel-core": "^6.8.0",
     "babel-eslint": "^6.0.2",
-    "babel-loader": "~5.3.2",
+    "babel-loader": "~6.2.4",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-stage-0": "^6.5.0",
+    "babel-preset-react": "^6.5.0",
     "chai": "^3.2.0",
     "chai-spies": "^0.7.1",
     "eslint": "^2.7.0",

--- a/src/decorator.js
+++ b/src/decorator.js
@@ -1,22 +1,21 @@
-import LazyLoad from './index';
+import LazyLoad from '.';
 import React, { Component } from 'react';
 
-const getDisplayName = (WrappedComponent) => {
-  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
-};
+const getDisplayName = (WrappedComponent) => WrappedComponent.displayName || WrappedComponent.name || 'Component';
 
-export default (options = {}) => {
-  return function lazyload(WrappedComponent) {
-    return class LazyLoadDecorated extends Component {
-      static displayName = `LazyLoad${getDisplayName(WrappedComponent)}`;
+export default (options = {}) => function lazyload(WrappedComponent) {
+  return class LazyLoadDecorated extends Component {
+    constructor() {
+      super();
+      this.displayName = `LazyLoad${getDisplayName(WrappedComponent)}`;
+    }
 
-      render() {
-        return (
-          <LazyLoad {...options}>
-            <WrappedComponent {...this.props} />
-          </LazyLoad>
-        );
-      }
-    };
+    render() {
+      return (
+        <LazyLoad {...options}>
+          <WrappedComponent {...this.props} />
+        </LazyLoad>
+      );
+    }
   };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -211,7 +211,7 @@ class LazyLoad extends Component {
         const node = ReactDom.findDOMNode(this);
         if (!warnedAboutPlaceholderHeight &&
             Math.abs(node.offsetHeight - this.props.height) > heightDiffThreshold) {
-          console.warn(`[react-lazyload] A more specific \`height\` or \`minHeight\` for your own placeholder will result better lazyload performance.`);
+          console.warn('[react-lazyload] A more specific `height` or `minHeight` for your own placeholder will result better lazyload performance.');
           warnedAboutPlaceholderHeight = true;
         }
       }
@@ -273,6 +273,6 @@ LazyLoad.defaultProps = {
   scroll: true
 };
 
+import decorator from './decorator';
+export const lazyload = decorator;
 export default LazyLoad;
-
-export lazyload from './decorator';

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -2,7 +2,7 @@
 // Generated on Wed Mar 18 2015 11:41:18 GMT+0800 (CST)
 'use strict';
 
-module.exports = function(config) {
+module.exports = function (config) {
   config.set({
 
     // base path that will be used to resolve all patterns (eg. files, exclude)
@@ -13,9 +13,9 @@ module.exports = function(config) {
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
     frameworks: ['mocha', 'chai'],
 
-    // list of files / patterns to l/oad in the browser
+    // list of files / patterns to load in the browser
     files: [
-      {pattern: 'test/specs/*.js', included: true, watched: false},
+      { pattern: 'test/specs/*.js', included: true, watched: false },
     ],
 
 
@@ -39,7 +39,11 @@ module.exports = function(config) {
         loaders: [{
           test: /\.js$/,
           include: /src|test|demo/,
-          loader: 'babel?stage=0&loose=all'
+          query: {
+            presets: ['stage-0', 'es2015', 'react'],
+            plugins: ['transform-decorators-legacy']
+          },
+          loader: 'babel'
         }],
         postLoaders: [{
           test: /\.js$/,

--- a/test/specs/lazyload.spec.js
+++ b/test/specs/lazyload.spec.js
@@ -132,7 +132,7 @@ describe('LazyLoad', () => {
           </LazyLoad>
         </div>, div);
 
-      expect(log).to.have.been.called.with(`[react-lazyload] A more specific \`height\` or \`minHeight\` for your own placeholder will result better lazyload performance.`);
+      expect(log).to.have.been.called.with('[react-lazyload] A more specific `height` or `minHeight` for your own placeholder will result better lazyload performance.');
       console.warn = warn;
     });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,11 @@ module.exports = {
   module: {
     loaders: [{
       test: /\.jsx?$/,
-      loader: 'babel?stage=0&loose=all',
+      loader: 'babel',
+      query: {
+        presets: ['stage-0', 'es2015'],
+        plugins: ['transform-react-jsx', 'transform-decorators-legacy']
+      },
       exclude: /node_modules/
     }]
   },


### PR DESCRIPTION
Not quite ready.

```
Firefox 44.0.0 (Mac OS X 10.11.0) LazyLoad Decorator should work properly FAILED
    _src.lazyload is not a function
    @/Users/doug.wade/code/react-lazyload/test/specs/lazyload.spec.js:397:28 <- webpack:///test/specs/lazyload.spec.js:195:7

WARN: '[react-lazyload] Previous delay function is `throttle`, now switching to `debounce`, try to set them unanimously'
Firefox 44.0.0 (Mac OS X 10.11.0): Executed 13 of 13 (1 FAILED) (3.665 secs / 3.58 secs)
------------------|----------|----------|----------|----------|----------------|
File              |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
------------------|----------|----------|----------|----------|----------------|
 src/             |    78.24 |    57.42 |    64.71 |    87.27 |                |
  decorator.js    |       32 |    10.53 |    15.38 |       52 |... 41,44,47,55 |
  index.js        |    92.17 |    72.65 |    95.24 |    93.57 |... 204,205,241 |
 src/utils/       |    92.31 |    69.57 |       90 |    92.31 |                |
  debounce.js     |    92.86 |    71.43 |      100 |    92.86 |          41,42 |
  event.js        |    92.86 |       60 |    66.67 |    92.86 |             13 |
  scrollParent.js |    85.71 |    64.29 |      100 |    85.71 |       12,31,41 |
  throttle.js     |      100 |     87.5 |      100 |      100 |                |
------------------|----------|----------|----------|----------|----------------|
All files         |    81.97 |     60.2 |    70.45 |    88.89 |                |
------------------|----------|----------|----------|----------|----------------|
```
